### PR TITLE
Added udev rule for DMXCreator USB interface

### DIFF
--- a/etc/udev/rules.d/10-local.rules
+++ b/etc/udev/rules.d/10-local.rules
@@ -16,6 +16,9 @@ SUBSYSTEM=="usb|usb_device", ACTION=="add", ATTRS{idVendor}=="10cf", ATTRS{idPro
 # udev rules for the DMXControl Projects e.V. Nodle U1
 SUBSYSTEM=="usb|usb_device", ACTION=="add", ATTRS{idVendor}=="16d0", ATTRS{idProduct}=="0830", GROUP="plugdev"
 
+# udev rules for the DMXCreator 512 Basic device
+SUBSYSTEM=="usb|usb_device", ACTION=="add", ATTRS{idVendor}=="0a30", ATTRS{idProduct}=="0002", GROUP="plugdev"
+
 # udev rules for the Eurolite
 SUBSYSTEM=="usb|usb_device", ACTION=="add", ATTRS{idVendor}=="04d8", ATTRS{idProduct}=="fa63", GROUP="plugdev" MODE="660"
 


### PR DESCRIPTION
See https://github.com/OpenLightingProject/ola/pull/1136